### PR TITLE
Customizable Bonsai inner content

### DIFF
--- a/bonsai-core/src/commonMain/kotlin/cafe/adriel/bonsai/core/Bonsai.kt
+++ b/bonsai-core/src/commonMain/kotlin/cafe/adriel/bonsai/core/Bonsai.kt
@@ -80,7 +80,7 @@ public fun <T> Bonsai(
     Bonsai(
         tree = tree,
         content = {
-            DefaultBonsaiTreeNodes(tree, modifier)
+            BonsaiVerticalTreeNodes(tree, modifier)
         },
         onClick = onClick,
         onDoubleClick = onDoubleClick,
@@ -113,7 +113,7 @@ public fun <T> Bonsai(
 }
 
 @Composable
-public fun <T> BonsaiScope<T>.DefaultBonsaiTreeNodes(tree: Tree<T>, modifier: Modifier = Modifier) {
+public fun <T> BonsaiVerticalTreeNodes(tree: Tree<T>, modifier: Modifier = Modifier) {
     LazyColumn(
         modifier = modifier
             .fillMaxWidth()

--- a/bonsai-core/src/commonMain/kotlin/cafe/adriel/bonsai/core/Bonsai.kt
+++ b/bonsai-core/src/commonMain/kotlin/cafe/adriel/bonsai/core/Bonsai.kt
@@ -77,6 +77,27 @@ public fun <T> Bonsai(
     onLongClick: OnNodeClick<T> = tree::toggleSelection,
     style: BonsaiStyle<T> = BonsaiStyle(),
 ) {
+    Bonsai(
+        tree = tree,
+        content = {
+            DefaultBonsaiTreeNodes(tree, modifier)
+        },
+        onClick = onClick,
+        onDoubleClick = onDoubleClick,
+        onLongClick = onLongClick,
+        style = style,
+    )
+}
+
+@Composable
+public fun <T> Bonsai(
+    tree: Tree<T>,
+    content: @Composable BonsaiScope<T>.() -> Unit,
+    onClick: OnNodeClick<T> = tree::onNodeClick,
+    onDoubleClick: OnNodeClick<T> = tree::onNodeClick,
+    onLongClick: OnNodeClick<T> = tree::toggleSelection,
+    style: BonsaiStyle<T> = BonsaiStyle(),
+) {
     val scope = remember(tree) {
         BonsaiScope(
             expandableManager = tree,
@@ -88,15 +109,18 @@ public fun <T> Bonsai(
         )
     }
 
-    with(scope) {
-        LazyColumn(
-            modifier = modifier
-                .fillMaxWidth()
-                .horizontalScroll(rememberScrollState())
-        ) {
-            items(tree.nodes, { it.key }) { node ->
-                Node(node)
-            }
+    content(scope)
+}
+
+@Composable
+public fun <T> BonsaiScope<T>.DefaultBonsaiTreeNodes(tree: Tree<T>, modifier: Modifier = Modifier) {
+    LazyColumn(
+        modifier = modifier
+            .fillMaxWidth()
+            .horizontalScroll(rememberScrollState())
+    ) {
+        items(tree.nodes, { node -> node.key }) { node ->
+            Node(node)
         }
     }
 }

--- a/bonsai-core/src/commonMain/kotlin/cafe/adriel/bonsai/core/node/UiNode.kt
+++ b/bonsai-core/src/commonMain/kotlin/cafe/adriel/bonsai/core/node/UiNode.kt
@@ -24,12 +24,13 @@ import androidx.compose.ui.unit.times
 import cafe.adriel.bonsai.core.BonsaiScope
 
 @Composable
-internal fun <T> BonsaiScope<T>.Node(
-    node: Node<T>
+public fun <T> BonsaiScope<T>.Node(
+    node: Node<T>,
+    modifier: Modifier = Modifier,
 ) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
-        modifier = Modifier
+        modifier = modifier
             .padding(vertical = 1.dp)
             .padding(start = node.depth * style.toggleIconSize)
     ) {


### PR DESCRIPTION
Gives more flexibility to create Bonsais so that can be implemented in the way that best adapts to the code of whoever is using it.

```kotlin
Bonsai(tree) { // this: BonsaiScope<T>
}
```

Default behavior is public as well

```kotlin
BonsaiVerticalTreeNodes(tree)
```