### PR TITLE
Update Gradle, Kotlin and Compose

### DIFF
--- a/android-module.gradle
+++ b/android-module.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdk 31
+    compileSdk 34
     defaultConfig {
         minSdk 21
         targetSdk 31

--- a/android-module.gradle
+++ b/android-module.gradle
@@ -20,6 +20,5 @@ android {
     }
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_11.toString()
-        useIR = true
     }
 }

--- a/buildSrc/src/main/kotlin/Setup.kt
+++ b/buildSrc/src/main/kotlin/Setup.kt
@@ -8,7 +8,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import com.android.build.gradle.LibraryExtension
 
 private fun BaseExtension.android() {
-    compileSdkVersion(31)
+    compileSdkVersion(34)
     defaultConfig {
         minSdk = 21
         targetSdk = 31

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,9 +4,9 @@ plugin-ktlint = "10.2.1"
 plugin-detekt = "1.20.0-RC1"
 plugin-maven = "0.18.0"
 
-kotlin = "1.8.20"
+kotlin = "1.8.21"
 okio = "3.0.0"
-serialization = "1.6.0"
+serialization = "1.5.1"
 
 compose = "1.5.0"
 composeMultiplatform = "1.5.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,14 +4,15 @@ plugin-ktlint = "10.2.1"
 plugin-detekt = "1.20.0-RC1"
 plugin-maven = "0.18.0"
 
-kotlin = "1.8.21"
+kotlin = "1.8.22"
 okio = "3.0.0"
 serialization = "1.5.1"
 
-compose = "1.5.0"
-composeMultiplatform = "1.5.0"
+compose = "1.4.8"
+composeMultiplatform = "1.4.3"
 composeActivity = "1.7.2"
 composeVoyager = "1.0.0-beta16"
+material = "1.4.3"
 
 [libraries]
 plugin-android = { module = "com.android.tools.build:gradle", version.ref = "plugin-android" }
@@ -26,8 +27,8 @@ okio = { module = "com.squareup.okio:okio", version.ref = "okio" }
 serialization = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "serialization" }
 
 compose-runtime = { module = "androidx.compose.runtime:runtime", version.ref = "compose" }
-compose-material = { module = "androidx.compose.material:material", version.ref = "compose" }
-compose-material-icons = { module = "androidx.compose.material:material-icons-extended", version.ref = "compose" }
+compose-material = { module = "androidx.compose.material:material", version.ref = "material" }
+compose-material-icons = { module = "androidx.compose.material:material-icons-extended", version.ref = "material" }
 compose-activity = { module = "androidx.activity:activity-compose", version.ref = "composeActivity" }
 compose-voyager = { module = "cafe.adriel.voyager:voyager-navigator", version.ref = "composeVoyager" }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,16 +1,16 @@
 [versions]
-plugin-android = "7.1.2"
+plugin-android = "7.1.3"
 plugin-ktlint = "10.2.1"
 plugin-detekt = "1.20.0-RC1"
 plugin-maven = "0.18.0"
 
-kotlin = "1.6.10"
+kotlin = "1.8.20"
 okio = "3.0.0"
-serialization = "1.3.2"
+serialization = "1.6.0"
 
-compose = "1.1.1"
-composeMultiplatform = "1.1.1"
-composeActivity = "1.4.0"
+compose = "1.5.0"
+composeMultiplatform = "1.5.0"
+composeActivity = "1.7.2"
 composeVoyager = "1.0.0-beta16"
 
 [libraries]

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Dependency updates required for iOS support.

We will be upgrading to Kotlin 1.9.* after some analysis of the project's current build structure so we will be stuck with 1.8.22 for now.

Gradle also updated. Sample-related dependencies wasn't updated.