### PR TITLE
Prevent making node clickable if there is no such action

### DIFF
--- a/bonsai-core/src/commonMain/kotlin/cafe/adriel/bonsai/core/node/UiNode.kt
+++ b/bonsai-core/src/commonMain/kotlin/cafe/adriel/bonsai/core/node/UiNode.kt
@@ -92,7 +92,9 @@ private fun <T> BonsaiScope<T>.NodeContent(
 private fun <T> BonsaiScope<T>.clickableNode(
     node: Node<T>
 ): Modifier =
-    if (onLongClick == null && onDoubleClick == null) {
+    if (onClick == null && onLongClick == null && onDoubleClick == null) {
+        Modifier // no click action, return a noop modifier
+    } else if (onLongClick == null && onDoubleClick == null) {
         Modifier.clickable { onClick?.invoke(node) }
     } else {
         Modifier.combinedClickable(


### PR DESCRIPTION
While implementing a tree that has checkboxes in its nodes, I found that bonsai will insert a `clickable` modifier even if there is no click action.

This means that the UI will have overlapping hover and click animations when trying to use those custom elements within the tree:
![image](https://github.com/adrielcafe/bonsai/assets/27009727/0cc98467-477e-472b-a75b-418c50f30f73)

This PR fixes the issue when `Bonsai` is called with `onClick = null, onLongClick = null, onDoubleClick = null`.