### PR TITLE
Update dependencies & Clean up deprecated stuff in build scripts

### DIFF
--- a/bonsai-core/build.gradle.kts
+++ b/bonsai-core/build.gradle.kts
@@ -5,11 +5,11 @@ plugins {
     id("com.vanniktech.maven.publish")
 }
 
-kotlinMultiplatform()
+kotlinMultiplatform("cafe.adriel.bonsai.core")
 
 kotlin {
     sourceSets {
-        val commonMain by getting {
+        commonMain {
             dependencies {
                 compileOnly(compose.runtime)
                 compileOnly(compose.foundation)

--- a/bonsai-file-system/build.gradle.kts
+++ b/bonsai-file-system/build.gradle.kts
@@ -5,11 +5,11 @@ plugins {
     id("com.vanniktech.maven.publish")
 }
 
-kotlinMultiplatform()
+kotlinMultiplatform("cafe.adriel.bonsai.filesystem")
 
 kotlin {
     sourceSets {
-        val commonMain by getting {
+        commonMain {
             dependencies {
                 api(projects.bonsaiCore)
                 api(libs.okio)

--- a/bonsai-json/build.gradle.kts
+++ b/bonsai-json/build.gradle.kts
@@ -6,11 +6,11 @@ plugins {
     id("com.vanniktech.maven.publish")
 }
 
-kotlinMultiplatform()
+kotlinMultiplatform("cafe.adriel.bonsai.json")
 
 kotlin {
     sourceSets {
-        val commonMain by getting {
+        commonMain {
             dependencies {
                 api(projects.bonsaiCore)
                 api(libs.serialization)

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,5 +1,3 @@
-enableFeaturePreview("VERSION_CATALOGS")
-
 dependencyResolutionManagement {
     versionCatalogs {
         create("libs") {
@@ -7,3 +5,5 @@ dependencyResolutionManagement {
         }
     }
 }
+
+rootProject.name = "buildSrc"

--- a/buildSrc/src/main/kotlin/Setup.kt
+++ b/buildSrc/src/main/kotlin/Setup.kt
@@ -6,8 +6,10 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.gradle.kotlin.dsl.*
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import com.android.build.gradle.LibraryExtension
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 
-private fun BaseExtension.android() {
+private fun BaseExtension.android(namespace: String) {
+    this.namespace = namespace
     compileSdkVersion(34)
     defaultConfig {
         minSdk = 21
@@ -17,50 +19,35 @@ private fun BaseExtension.android() {
     }
 }
 
+@OptIn(ExperimentalKotlinGradlePluginApi::class)
 fun Project.kotlinMultiplatform(
+    namespace: String,
     explicitMode: Boolean = true
 ) {
     extensions.configure<KotlinMultiplatformExtension> {
-        android {
+        androidTarget {
             publishAllLibraryVariants()
         }
         jvm("desktop")
 
-        sourceSets {
-            /* Source sets structure
+        /* Source sets structure
             common
-              ├─ jvm
+              ├─ jvmShared
                   ├─ android
                   ├─ desktop
-             */
-            val commonMain by getting
-            val commonTest by getting
-
-            val jvmMain by creating {
-                dependsOn(commonMain)
-            }
-            val jvmTest by creating {
-                dependsOn(commonTest)
-            }
-
-            val androidMain by getting {
-                dependsOn(jvmMain)
-            }
-            val androidTest by getting {
-                dependsOn(jvmTest)
-            }
-
-            val desktopMain by getting {
-                dependsOn(jvmMain)
-            }
-            val desktopTest by getting {
-                dependsOn(jvmTest)
+         */
+        applyHierarchyTemplate {
+            common {
+                group("jvmShared") {
+                    withAndroidTarget()
+                    withJvm()
+                }
             }
         }
     }
 
     extensions.configure<LibraryExtension> {
-        android()
+        android(namespace)
         sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
     }
 

--- a/buildSrc/src/main/kotlin/Setup.kt
+++ b/buildSrc/src/main/kotlin/Setup.kt
@@ -32,13 +32,13 @@ fun Project.kotlinMultiplatform(
 
         /* Source sets structure
             common
-              ├─ jvmShared
+              ├─ jvm
                   ├─ android
                   ├─ desktop
          */
         applyHierarchyTemplate {
             common {
-                group("jvmShared") {
+                group("jvm") {
                     withAndroidTarget()
                     withJvm()
                 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ org.gradle.jvmargs=-Xmx4096m -Dfile.encoding=UTF-8
 android.useAndroidX=true
 android.enableJetifier=true
 kotlin.code.style=official
-kotlin.mpp.enableGranularSourceSetsMetadata=true
+kotlin.mpp.androidGradlePluginCompatibility.nowarn=true
 
 # Maven
 GROUP=cafe.adriel.bonsai

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,18 +1,18 @@
 [versions]
-plugin-android = "7.1.3"
-plugin-ktlint = "10.2.1"
-plugin-detekt = "1.20.0-RC1"
+plugin-android = "8.3.1"
+plugin-ktlint = "12.1.0"
+plugin-detekt = "1.23.6"
 plugin-maven = "0.18.0"
 
-kotlin = "1.8.22"
-okio = "3.0.0"
-serialization = "1.5.1"
+kotlin = "1.9.23"
+okio = "3.9.0"
+serialization = "1.6.3"
 
-compose = "1.4.8"
-composeMultiplatform = "1.4.3"
-composeActivity = "1.7.2"
-composeVoyager = "1.0.0-beta16"
-material = "1.4.3"
+compose = "1.6.5"
+composeMultiplatform = "1.6.1"
+composeActivity = "1.8.2"
+composeVoyager = "1.0.0"
+material = "1.6.5"
 
 [libraries]
 plugin-android = { module = "com.android.tools.build:gradle", version.ref = "plugin-android" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,8 @@ kotlin = "1.9.23"
 okio = "3.9.0"
 serialization = "1.6.3"
 
-compose = "1.6.5"
+compose = "1.5.11"
+composeRuntime = "1.6.5"
 composeMultiplatform = "1.6.1"
 composeActivity = "1.8.2"
 composeVoyager = "1.0.0"
@@ -26,7 +27,7 @@ plugin-compose-multiplatform = { module = "org.jetbrains.compose:compose-gradle-
 okio = { module = "com.squareup.okio:okio", version.ref = "okio" }
 serialization = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "serialization" }
 
-compose-runtime = { module = "androidx.compose.runtime:runtime", version.ref = "compose" }
+compose-runtime = { module = "androidx.compose.runtime:runtime", version.ref = "composeRuntime" }
 compose-material = { module = "androidx.compose.material:material", version.ref = "material" }
 compose-material-icons = { module = "androidx.compose.material:material-icons-extended", version.ref = "material" }
 compose-activity = { module = "androidx.activity:activity-compose", version.ref = "composeActivity" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -6,6 +6,7 @@ plugins {
 apply from: "../android-module.gradle"
 
 android {
+    namespace = "cafe.adriel.bonsai.sample"
     defaultConfig {
         applicationId "cafe.adriel.bonsai.sample"
     }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,6 +7,7 @@ dependencyResolutionManagement {
     }
 }
 
+rootProject.name = "bonsai"
 include(
     ":sample",
     ":bonsai-core",
@@ -14,5 +15,4 @@ include(
     ":bonsai-json",
 )
 
-enableFeaturePreview("VERSION_CATALOGS")
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")


### PR DESCRIPTION
- Add required attributes like namespace.
- Remove old sourceSets customization setup in favor of new `applyHierarchyTemplate`.